### PR TITLE
feat: adding helper to check if post/comment belongs to the user (for user role)

### DIFF
--- a/backend/internal/server/authorization.go
+++ b/backend/internal/server/authorization.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -10,6 +12,11 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+)
+
+var (
+	errInvalidResourceID   = errors.New("invalid resource ID")
+	errUnsupportedResource = errors.New("unsupported resource for ownership check")
 )
 
 func PermissionHumaMiddleware(api huma.API, db *gorm.DB) func(huma.Context, func(huma.Context)) {
@@ -51,9 +58,13 @@ func PermissionHumaMiddleware(api huma.API, db *gorm.DB) func(huma.Context, func
 		if (action == models.PermissionUpdate || action == models.PermissionDelete) &&
 			(resource == "post" || resource == "comment") &&
 			ctx.Param("id") != "" {
-			owned, status, msg := IsOwnerOfPostOrComment(db, parsedUserID, ctx.Param("id"), resource)
-			if status != 0 {
-				_ = huma.WriteErr(api, ctx, status, msg)
+			owned, err := IsOwnerOfPostOrComment(db, parsedUserID, ctx.Param("id"), resource)
+			if err != nil {
+				status := http.StatusInternalServerError
+				if errors.Is(err, errInvalidResourceID) || errors.Is(err, errUnsupportedResource) {
+					status = http.StatusBadRequest
+				}
+				_ = huma.WriteErr(api, ctx, status, err.Error())
 				return
 			}
 			if owned {
@@ -94,10 +105,10 @@ func authorizeByPermission(db *gorm.DB, userID uuid.UUID, action models.Permissi
 	return true, 0, ""
 }
 
-func IsOwnerOfPostOrComment(db *gorm.DB, userID uuid.UUID, resourceID, resource string) (bool, int, string) {
+func IsOwnerOfPostOrComment(db *gorm.DB, userID uuid.UUID, resourceID, resource string) (bool, error) {
 	parsedResourceID, err := uuid.Parse(resourceID)
 	if err != nil {
-		return false, http.StatusBadRequest, "Invalid resource ID"
+		return false, errInvalidResourceID
 	}
 
 	var count int64
@@ -111,13 +122,13 @@ func IsOwnerOfPostOrComment(db *gorm.DB, userID uuid.UUID, resourceID, resource 
 			Where("id = ? AND user_id = ?", parsedResourceID, userID).
 			Count(&count).Error
 	default:
-		return false, http.StatusBadRequest, "Unsupported resource for ownership check"
+		return false, errUnsupportedResource
 	}
 
 	if err != nil {
-		return false, http.StatusInternalServerError, "Unable to check ownership"
+		return false, fmt.Errorf("unable to check ownership: %w", err)
 	}
-	return count > 0, 0, ""
+	return count > 0, nil
 }
 
 func resolveResourceAndAction(method, path, userID, pathID string) (models.PermissionAction, string) {

--- a/backend/internal/tests/unit_tests/authorization_test.go
+++ b/backend/internal/tests/unit_tests/authorization_test.go
@@ -2,7 +2,6 @@ package unitTests
 
 import (
 	"context"
-	"net/http"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -70,24 +69,29 @@ func TestIsOwnerOfPostOrComment(t *testing.T) {
 		t.Fatalf("failed to create comment: %v", err)
 	}
 
-	owned, status, msg := server.IsOwnerOfPostOrComment(testDB.DB, userID, post.ID.String(), "post")
-	if status != 0 || msg != "" || !owned {
-		t.Fatalf("expected owner for post, got owned=%v status=%d msg=%q", owned, status, msg)
+	owned, err := server.IsOwnerOfPostOrComment(testDB.DB, userID, post.ID.String(), "post")
+	if err != nil || !owned {
+		t.Fatalf("expected owner for post, got owned=%v err=%v", owned, err)
 	}
 
-	owned, status, msg = server.IsOwnerOfPostOrComment(testDB.DB, otherUserID, post.ID.String(), "post")
-	if status != 0 || msg != "" || owned {
-		t.Fatalf("expected non-owner for post, got owned=%v status=%d msg=%q", owned, status, msg)
+	owned, err = server.IsOwnerOfPostOrComment(testDB.DB, otherUserID, post.ID.String(), "post")
+	if err != nil || owned {
+		t.Fatalf("expected non-owner for post, got owned=%v err=%v", owned, err)
 	}
 
-	owned, status, msg = server.IsOwnerOfPostOrComment(testDB.DB, userID, comment.ID.String(), "comment")
-	if status != 0 || msg != "" || !owned {
-		t.Fatalf("expected owner for comment, got owned=%v status=%d msg=%q", owned, status, msg)
+	owned, err = server.IsOwnerOfPostOrComment(testDB.DB, userID, comment.ID.String(), "comment")
+	if err != nil || !owned {
+		t.Fatalf("expected owner for comment, got owned=%v err=%v", owned, err)
 	}
 
-	owned, status, _ = server.IsOwnerOfPostOrComment(testDB.DB, userID, post.ID.String(), "sport")
-	if status != http.StatusBadRequest || owned {
-		t.Fatalf("expected bad request for unsupported resource, got owned=%v status=%d", owned, status)
+	owned, err = server.IsOwnerOfPostOrComment(testDB.DB, userID, post.ID.String(), "sport")
+	if err == nil || owned {
+		t.Fatalf("expected error for unsupported resource, got owned=%v err=%v", owned, err)
+	}
+
+	owned, err = server.IsOwnerOfPostOrComment(testDB.DB, userID, "not-a-uuid", "post")
+	if err == nil || owned {
+		t.Fatalf("expected error for invalid resource ID, got owned=%v err=%v", owned, err)
 	}
 }
 


### PR DESCRIPTION
# Description

[Link to Ticket](https://github.com/GenerateNU/inside-athletics/issues/41)
Added a helper method that checks (using the userID) if the user (who is a user role) owns the post or comment and only then allows the user to update/delete the post or comment. Also wrote a unit test for it.

Please include a summary of the changes. If there were unexpected changes 
to separate processes/components/dependencies, please explain why. Bullet list is fine!

# Backend PRs:

- [x] I updated relevant API documentation and tests

# Frontend PRs:

Page route(and description of how to get desired flow if necessary)

Please include any relevant images of the changes here.

NO FRONT END

# Did any new/other issues pop up?

No

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
