### PR TITLE
Fix: fixing race conditions and error handling

### DIFF
--- a/backend/internal/handlers/post/post_db.go
+++ b/backend/internal/handlers/post/post_db.go
@@ -1,6 +1,7 @@
 package post
 
 import (
+	"errors"
 	models "inside-athletics/internal/models"
 	"inside-athletics/internal/utils"
 	"math"
@@ -15,6 +16,11 @@ type PostDB struct {
 	db *gorm.DB
 }
 
+var (
+	ErrFreePostCreationLimitReached = errors.New("free-tier post creation limit reached")
+	ErrFreePostViewLimitReached     = errors.New("free-tier post view limit reached")
+)
+
 // NewPostDB creates a new PostDB instance
 func NewPostDB(db *gorm.DB) *PostDB {
 	return &PostDB{db: db}
@@ -23,20 +29,35 @@ func NewPostDB(db *gorm.DB) *PostDB {
 // CreatePost creates a new sport in the database
 func (s *PostDB) CreatePost(post *models.Post, tags []TagRequest) (*models.Post, error) {
 	dbError := s.db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Create(&post).Error; err != nil {
-			return err
-		}
-		var tagModels []models.Tag
-		for _, t := range tags {
-			tagModels = append(tagModels, models.Tag{ID: t.ID})
-		}
-		if err := tx.Model(&post).Association("Tags").Append(&tagModels); err != nil {
+		return s.createPostTx(tx, post, tags)
+	})
+	return utils.HandleDBError(post, dbError)
+}
+
+// CreatePostWithAuthorLimit creates a post while enforcing the author's post cap atomically.
+func (s *PostDB) CreatePostWithAuthorLimit(post *models.Post, tags []TagRequest, maxPosts int64) (*models.Post, error) {
+	dbError := s.db.Transaction(func(tx *gorm.DB) error {
+		if err := s.lockUserForUpdate(tx, post.AuthorID); err != nil {
 			return err
 		}
 
-		return nil
+		var count int64
+		if err := tx.Model(&models.Post{}).Where("author_id = ?", post.AuthorID).Count(&count).Error; err != nil {
+			return err
+		}
+		if count >= maxPosts {
+			return ErrFreePostCreationLimitReached
+		}
+
+		return s.createPostTx(tx, post, tags)
 	})
-	return utils.HandleDBError(post, dbError)
+	if dbError != nil {
+		if errors.Is(dbError, ErrFreePostCreationLimitReached) {
+			return nil, dbError
+		}
+		return utils.HandleDBError(post, dbError)
+	}
+	return post, nil
 }
 
 // CountViewedPostsByUser returns the number of distinct posts the user has viewed (for free-tier limit).
@@ -59,11 +80,74 @@ func (s *PostDB) RecordPostView(userID, postID uuid.UUID) error {
 	return s.db.Where("user_id = ? AND post_id = ?", userID, postID).FirstOrCreate(v).Error
 }
 
+// RecordPostViewIfAllowed records a new post view while enforcing the user's distinct-view cap atomically.
+func (s *PostDB) RecordPostViewIfAllowed(userID, postID uuid.UUID, maxViews int64) error {
+	dbError := s.db.Transaction(func(tx *gorm.DB) error {
+		if err := s.lockUserForUpdate(tx, userID); err != nil {
+			return err
+		}
+
+		var existing models.ViewedPost
+		err := tx.Where("user_id = ? AND post_id = ?", userID, postID).Take(&existing).Error
+		switch {
+		case err == nil:
+			return nil
+		case !errors.Is(err, gorm.ErrRecordNotFound):
+			return err
+		}
+
+		var count int64
+		if err := tx.Model(&models.ViewedPost{}).Where("user_id = ?", userID).Count(&count).Error; err != nil {
+			return err
+		}
+		if count >= maxViews {
+			return ErrFreePostViewLimitReached
+		}
+
+		return tx.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "user_id"}, {Name: "post_id"}},
+			DoNothing: true,
+		}).Create(&models.ViewedPost{UserID: userID, PostID: postID}).Error
+	})
+	if dbError != nil {
+		if errors.Is(dbError, ErrFreePostViewLimitReached) {
+			return dbError
+		}
+		_, err := utils.HandleDBError((*models.ViewedPost)(nil), dbError)
+		return err
+	}
+	return nil
+}
+
 // CountPostsByAuthor returns how many posts the user has created (for free-tier create limit).
 func (s *PostDB) CountPostsByAuthor(authorID uuid.UUID) (int64, error) {
 	var count int64
 	err := s.db.Model(&models.Post{}).Where("author_id = ?", authorID).Count(&count).Error
 	return count, err
+}
+
+func (s *PostDB) createPostTx(tx *gorm.DB, post *models.Post, tags []TagRequest) error {
+	if err := tx.Create(post).Error; err != nil {
+		return err
+	}
+	var tagModels []models.Tag
+	for _, t := range tags {
+		tagModels = append(tagModels, models.Tag{ID: t.ID})
+	}
+	if err := tx.Model(post).Association("Tags").Append(&tagModels); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *PostDB) lockUserForUpdate(tx *gorm.DB, userID uuid.UUID) error {
+	return tx.
+		Model(&models.User{}).
+		Select("id").
+		Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("id = ?", userID).
+		Take(&models.User{}).Error
 }
 
 // GetPostByID retrieves a post by its ID

--- a/backend/internal/handlers/post/post_service.go
+++ b/backend/internal/handlers/post/post_service.go
@@ -2,6 +2,7 @@ package post
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"inside-athletics/internal/handlers/tagpost"
 	"inside-athletics/internal/handlers/user"
@@ -19,7 +20,10 @@ const (
 	FreeUserMaxPosts     = 1
 )
 
-const freeLimitMessage = "You have used up your free post views. Upgrade to view more posts."
+const (
+	freePostCreateLimitMessage = "You have used up your free post creation limit. Upgrade to create more posts."
+	freePostViewLimitMessage   = "You have used up your free post views. Upgrade to view more posts."
+)
 
 type PostService struct {
 	postDB    *PostDB
@@ -47,15 +51,13 @@ func (s *PostService) CreatePost(ctx context.Context, input *struct{ Body Create
 		return nil, err
 	}
 	if !u.Account_Type {
-		count, err := s.postDB.CountPostsByAuthor(id)
-		if err != nil {
-			return nil, err
-		}
-		if count >= FreeUserMaxPosts {
-			return nil, huma.Error403Forbidden(freeLimitMessage)
-		}
+		return s.createPost(id, input, true)
 	}
 
+	return s.createPost(id, input, false)
+}
+
+func (s *PostService) createPost(id uuid.UUID, input *struct{ Body CreatePostRequest }, enforceFreeTierLimit bool) (*utils.ResponseBody[CreatePostResponse], error) {
 	if len(input.Body.Tags) == 0 && input.Body.SportId == nil && input.Body.CollegeId == nil {
 		return nil, huma.Error400BadRequest("Need to have at least a single tag on a post")
 	}
@@ -68,11 +70,21 @@ func (s *PostService) CreatePost(ctx context.Context, input *struct{ Body Create
 		IsAnonymous: input.Body.IsAnonymous,
 	}
 
-	createdPost, err := utils.HandleDBError(
-		s.postDB.CreatePost(post, input.Body.Tags),
+	var (
+		createdPost *models.Post
+		err         error
 	)
-
+	if enforceFreeTierLimit {
+		createdPost, err = s.postDB.CreatePostWithAuthorLimit(post, input.Body.Tags, FreeUserMaxPosts)
+	} else {
+		createdPost, err = utils.HandleDBError(
+			s.postDB.CreatePost(post, input.Body.Tags),
+		)
+	}
 	if err != nil {
+		if errors.Is(err, ErrFreePostCreationLimitReached) {
+			return nil, huma.Error403Forbidden(freePostCreateLimitMessage)
+		}
 		return nil, err
 	}
 
@@ -163,21 +175,11 @@ func (s *PostService) GetPostByID(ctx context.Context, input *GetPostByIDParams)
 		return nil, err
 	}
 	if !u.Account_Type {
-		alreadyViewed, err := s.postDB.HasUserViewedPost(userID, input.ID)
-		if err != nil {
+		if err := s.postDB.RecordPostViewIfAllowed(userID, input.ID, FreeUserMaxPostViews); err != nil {
+			if errors.Is(err, ErrFreePostViewLimitReached) {
+				return nil, huma.Error403Forbidden(freePostViewLimitMessage)
+			}
 			return nil, err
-		}
-		if !alreadyViewed {
-			count, err := s.postDB.CountViewedPostsByUser(userID)
-			if err != nil {
-				return nil, err
-			}
-			if count >= FreeUserMaxPostViews {
-				return nil, huma.Error403Forbidden(freeLimitMessage)
-			}
-			if err := s.postDB.RecordPostView(userID, input.ID); err != nil {
-				return nil, err
-			}
 		}
 	}
 

--- a/backend/internal/handlers/role/role_db.go
+++ b/backend/internal/handlers/role/role_db.go
@@ -7,6 +7,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type RoleDB struct {
@@ -124,7 +125,7 @@ func (r *RoleDB) UpdateRoleWithPermissionsStrict(id uuid.UUID, updates UpdateRol
 
 	err := r.db.Transaction(func(tx *gorm.DB) error {
 		var role models.Role
-		if err := tx.First(&role, "id = ?", id).Error; err != nil {
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(&role, "id = ?", id).Error; err != nil {
 			if err == gorm.ErrRecordNotFound {
 				return huma.Error404NotFound("Resource not found")
 			}

--- a/backend/internal/handlers/role/role_db.go
+++ b/backend/internal/handlers/role/role_db.go
@@ -21,16 +21,10 @@ func (r *RoleDB) CreateRoleWithPermissionsStrict(spec RoleSpec) (*models.Role, e
 	var created *models.Role
 
 	err := r.db.Transaction(func(tx *gorm.DB) error {
-		var existing models.Role
-		if err := tx.Where("name = ?", spec.Name).First(&existing).Error; err == nil {
-			return huma.Error400BadRequest("Role already exists")
-		} else if err != gorm.ErrRecordNotFound {
-			return huma.Error500InternalServerError("Database error", err)
-		}
-
 		role := &models.Role{Name: spec.Name}
 		if err := tx.Create(role).Error; err != nil {
-			return huma.Error500InternalServerError("Failed to create role", err)
+			_, handleErr := utils.HandleDBError(&models.Role{}, err)
+			return handleErr
 		}
 
 		for _, p := range spec.Permissions {

--- a/backend/internal/tests/route_tests/post_test.go
+++ b/backend/internal/tests/route_tests/post_test.go
@@ -1,11 +1,13 @@
 package routeTests
 
 import (
+	"errors"
 	"inside-athletics/internal/handlers/post"
 	"inside-athletics/internal/models"
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -669,6 +671,66 @@ func TestFreeUserCannotCreateSecondPost(t *testing.T) {
 	}
 }
 
+func TestFreeUserConcurrentPostCreationEnforcesLimit(t *testing.T) {
+	testDB := SetupTestDB(t)
+	defer testDB.Teardown(t)
+
+	CreateUserAndSport(testDB, t)
+	postDB := post.NewPostDB(testDB.DB)
+
+	errs := make(chan error, 2)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			_, err := postDB.CreatePostWithAuthorLimit(&models.Post{
+				AuthorID:    JohnID,
+				SportID:     &SoccerID,
+				Title:       "Concurrent post " + strconv.Itoa(i),
+				Content:     "Content",
+				IsAnonymous: false,
+			}, []post.TagRequest{}, post.FreeUserMaxPosts)
+			errs <- err
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	var successCount int
+	var limitErrorCount int
+	for err := range errs {
+		switch {
+		case err == nil:
+			successCount++
+		case errors.Is(err, post.ErrFreePostCreationLimitReached):
+			limitErrorCount++
+		default:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	if successCount != 1 {
+		t.Fatalf("expected exactly one successful post creation, got %d", successCount)
+	}
+	if limitErrorCount != 1 {
+		t.Fatalf("expected exactly one free-tier limit error, got %d", limitErrorCount)
+	}
+
+	count, err := postDB.CountPostsByAuthor(JohnID)
+	if err != nil {
+		t.Fatalf("failed to count posts by author: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one persisted post, got %d", count)
+	}
+}
+
 // TestFreeUserGetPostReturns403AfterMaxViews asserts free users get 403 when viewing more than FreeUserMaxPostViews distinct posts.
 func TestFreeUserGetPostReturns403AfterMaxViews(t *testing.T) {
 	const maxViews = 5
@@ -725,6 +787,88 @@ func TestFreeUserGetPostReturns403AfterMaxViews(t *testing.T) {
 	respAgain := api.Get("/api/v1/post/"+postIDs[0].String(), authHeader)
 	if respAgain.Code != http.StatusOK {
 		t.Fatalf("re-viewing first post should still be 200, got %d: %s", respAgain.Code, respAgain.Body.String())
+	}
+}
+
+func TestFreeUserConcurrentDistinctPostViewsEnforceLimit(t *testing.T) {
+	testDB := SetupTestDB(t)
+	defer testDB.Teardown(t)
+
+	postDB := post.NewPostDB(testDB.DB)
+	CreateUserAndSport(testDB, t)
+
+	freeUserID := uuid.New()
+	freeUser := models.User{
+		ID:                      freeUserID,
+		FirstName:               "Free",
+		LastName:                "User",
+		Email:                   "free-concurrent@example.com",
+		Username:                "freeuser-concurrent",
+		Account_Type:            false,
+		Verified_Athlete_Status: models.VerifiedAthleteStatusPending,
+	}
+	if err := testDB.DB.Create(&freeUser).Error; err != nil {
+		t.Fatalf("failed to create free user: %v", err)
+	}
+
+	postIDs := make([]uuid.UUID, 0, post.FreeUserMaxPostViews+1)
+	for i := 0; i < post.FreeUserMaxPostViews+1; i++ {
+		createdPost, err := postDB.CreatePost(&models.Post{
+			AuthorID:    JohnID,
+			SportID:     &SoccerID,
+			Title:       "Concurrent view target " + strconv.Itoa(i),
+			Content:     "Content",
+			IsAnonymous: false,
+		}, []post.TagRequest{})
+		if err != nil {
+			t.Fatalf("failed to create post %d: %v", i, err)
+		}
+		postIDs = append(postIDs, createdPost.ID)
+	}
+
+	errs := make(chan error, len(postIDs))
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for _, postID := range postIDs {
+		wg.Add(1)
+		go func(postID uuid.UUID) {
+			defer wg.Done()
+			<-start
+			errs <- postDB.RecordPostViewIfAllowed(freeUserID, postID, post.FreeUserMaxPostViews)
+		}(postID)
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	var successCount int
+	var limitErrorCount int
+	for err := range errs {
+		switch {
+		case err == nil:
+			successCount++
+		case errors.Is(err, post.ErrFreePostViewLimitReached):
+			limitErrorCount++
+		default:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	if successCount != post.FreeUserMaxPostViews {
+		t.Fatalf("expected %d successful view records, got %d", post.FreeUserMaxPostViews, successCount)
+	}
+	if limitErrorCount != 1 {
+		t.Fatalf("expected exactly one free-tier view limit error, got %d", limitErrorCount)
+	}
+
+	count, err := postDB.CountViewedPostsByUser(freeUserID)
+	if err != nil {
+		t.Fatalf("failed to count viewed posts: %v", err)
+	}
+	if count != post.FreeUserMaxPostViews {
+		t.Fatalf("expected %d persisted viewed posts, got %d", post.FreeUserMaxPostViews, count)
 	}
 }
 

--- a/backend/internal/tests/route_tests/role_test.go
+++ b/backend/internal/tests/route_tests/role_test.go
@@ -83,3 +83,38 @@ func TestRoleCRUD(t *testing.T) {
 		t.Fatalf("expected status 200, got %d: %s", deleteResp.Code, deleteResp.Body.String())
 	}
 }
+
+func TestCreateRoleDuplicateReturnsConflict(t *testing.T) {
+	testDB := SetupTestDB(t)
+	defer testDB.Teardown(t)
+	api := testDB.API
+
+	adminRoleID := getRoleID(t, testDB.DB, models.RoleAdmin)
+	adminUserID := uuid.New()
+	adminUser := models.User{
+		ID:                      adminUserID,
+		FirstName:               "Admin",
+		LastName:                "User",
+		Email:                   "admin-dup@example.com",
+		Username:                "admin-dup",
+		Account_Type:            true,
+		Verified_Athlete_Status: models.VerifiedAthleteStatusPending,
+	}
+	if err := testDB.DB.Create(&adminUser).Error; err != nil {
+		t.Fatalf("failed to create admin user: %v", err)
+	}
+	assignRoleToUser(t, testDB.DB, adminUserID, adminRoleID)
+
+	roleName := "duplicate_role_" + uuid.NewString()
+	createBody := role.CreateRoleRequest{Name: roleName}
+
+	firstResp := api.Post("/api/v1/role/", createBody, "Authorization: Bearer "+adminUserID.String())
+	if firstResp.Code != http.StatusOK {
+		t.Fatalf("expected first create status 200, got %d: %s", firstResp.Code, firstResp.Body.String())
+	}
+
+	secondResp := api.Post("/api/v1/role/", createBody, "Authorization: Bearer "+adminUserID.String())
+	if secondResp.Code != http.StatusConflict {
+		t.Fatalf("expected duplicate create status 409, got %d: %s", secondResp.Code, secondResp.Body.String())
+	}
+}

--- a/backend/internal/tests/route_tests/role_test.go
+++ b/backend/internal/tests/route_tests/role_test.go
@@ -105,7 +105,7 @@ func TestCreateRoleDuplicateReturnsConflict(t *testing.T) {
 	}
 	assignRoleToUser(t, testDB.DB, adminUserID, adminRoleID)
 
-	roleName := "duplicate_role_" + uuid.NewString()
+	roleName := "dup_role_" + uuid.NewString()[:8]
 	createBody := role.CreateRoleRequest{Name: roleName}
 
 	firstResp := api.Post("/api/v1/role/", createBody, "Authorization: Bearer "+adminUserID.String())


### PR DESCRIPTION
# Description

[Link to Ticket](insert the link to your ticket inside the parenthesis here)

Please include a summary of the changes. If there were unexpected changes 
to separate processes/components/dependencies, please explain why. Bullet list is fine!

Fixed the free-tier post creation race in post_db.go and post_service.go by enforcing free-user post creation with a per-user row lock, so two concurrent requests can no longer both pass the “max 1 post” check and create two posts.

Fixed the free-tier post-view race in those same files by enforcing a lock for the user row, then checks whether that post was already viewed, counts distinct viewed posts, and records the new view. That closes the issue where several concurrent first-time views could all slip past the 5-post cap for free users.

Also fixed the role creation race in role_db.go. The code no longer does a separate “does this role already exist?” read before insert. It now relies on the database’s unique constraint and then will map duplicate-names to a 409 error instead of a 500 internal server error.

Fixed the role update that would mix up requests in role_db.go. The update transaction now locks the target role row before changing the role name and rewriting permissions, so overlapping updates to the same role no longer get mixed up mid-transaction and end up with a “last write wins” scenario.

I also got Claude to add regression coverage in post_test.go for concurrent free-tier post creation and concurrent distinct post views, and in role_test.go for duplicate role creation. Claude fixed that new role test once when the generated name exceeded the varchar(50) column limit.

# Backend PRs:

- [x] I updated relevant API documentation and tests

# Frontend PRs:

Page route(and description of how to get desired flow if necessary)

Please include any relevant images of the changes here.

# Did any new/other issues pop up?

No

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
